### PR TITLE
Updated launch image handler to work with iOS7+ default.

### DIFF
--- a/GCOLaunchImageTransition/GCOLaunchImageTransition.m
+++ b/GCOLaunchImageTransition/GCOLaunchImageTransition.m
@@ -214,6 +214,14 @@ NSString* const GCOLaunchImageTransitionHideNotification = @"GCOLaunchImageTrans
    {
       NSDictionary* infoDict = [[NSBundle mainBundle] infoDictionary];
       NSString* launchImageName = [infoDict valueForKey:@"UILaunchImageFile"];
+
+      if (launchImageName == nil) {
+         // iOS 7+ default handling of Launch Images
+         NSArray* launchImagesArray = [infoDict objectForKey:@"UILaunchImages"];
+         if (launchImagesArray && [launchImagesArray count] > 0) {
+            launchImageName = [[launchImagesArray objectAtIndex:0] valueForKey:@"UILaunchImageName"];
+         }
+      }
       
       launchImage = [UIImage imageNamed:launchImageName];
    }


### PR DESCRIPTION
Take a look at the `UILaunchImages` section in: https://developer.apple.com/library/ios/documentation/General/Reference/InfoPlistKeyReference/Articles/iPhoneOSKeys.html#//apple_ref/doc/uid/TP40009252-SW1
